### PR TITLE
Fix exceptions for twig rules

### DIFF
--- a/packages/twig-phpstan-compiler/src/PhpParser/NodeVisitor/TwigGetAttributeExpanderNodeVisitor.php
+++ b/packages/twig-phpstan-compiler/src/PhpParser/NodeVisitor/TwigGetAttributeExpanderNodeVisitor.php
@@ -121,6 +121,11 @@ final class TwigGetAttributeExpanderNodeVisitor extends NodeVisitorAbstract
     private function resolveVariableName(FuncCall $funcCall): string|null
     {
         // @todo match with provided type
+
+        if (! array_key_exists(2, $funcCall->getArgs())) {
+            return null;
+        }
+
         $variable = $funcCall->getArgs()[2]
             ->value;
 

--- a/packages/twig-phpstan-compiler/src/PhpParser/NodeVisitor/TwigGetAttributeExpanderNodeVisitor.php
+++ b/packages/twig-phpstan-compiler/src/PhpParser/NodeVisitor/TwigGetAttributeExpanderNodeVisitor.php
@@ -123,6 +123,11 @@ final class TwigGetAttributeExpanderNodeVisitor extends NodeVisitorAbstract
         // @todo match with provided type
         $variable = $funcCall->getArgs()[2]
             ->value;
+
+        if ($variable instanceof FuncCall) {
+            return $this->resolveVariableName($variable);
+        }
+
         if (! $variable instanceof Variable) {
             throw new ShouldNotHappenException();
         }

--- a/packages/twig-phpstan-compiler/tests/TwigToPhpCompiler/Fixture/function_param_nested.twig
+++ b/packages/twig-phpstan-compiler/tests/TwigToPhpCompiler/Fixture/function_param_nested.twig
@@ -1,0 +1,7 @@
+{{ func(var).method }}
+-----
+<?php
+
+// line 1
+echo \twig_get_attribute($this->env, $this->source, \call_user_func_array($this->env->getFunction('func')->getCallable(), [$var]), "method", [], "any", \false, \false, \false, 1);
+echo "\n";

--- a/packages/twig-phpstan-compiler/tests/TwigToPhpCompiler/Fixture/nested.twig
+++ b/packages/twig-phpstan-compiler/tests/TwigToPhpCompiler/Fixture/nested.twig
@@ -1,0 +1,7 @@
+{{ var.other.method }}
+-----
+<?php
+
+// line 1
+echo $var->method();
+echo "\n";


### PR DESCRIPTION
Without these two fixes, the test cases cause exceptions.

Unfortunately, the nested test case has a wrong result. 

```
{{ var.other.method }}
-----
<?php

// line 1
echo $var->method();
echo "\n";
```

This now causes an `Call to an undefined method $other->method` error, which is wrong, but at least more helpful than a `ShouldNotHappenException` and can be refactored to pass the rules.

I think the correct result should be:

```
{{ var.other.method }}
-----
<?php

// line 1
echo $var->other()->method();
echo "\n";
```

I worked on it for hours but I can't manage to achieve the recursive nesting 😞 . I was getting frustrated, so I thought I'd start the PR and discussion 😄 .

The nesting could also be an additional rule, like "max X levels of nesting/chained call". I'll add some thoughts on it in an issue.

With these and the refactoring from the other PR I can at least run the rules without exceptions in my project, so I think its a small step forward 🙂 . There seem to be few false positives so I use some ignore rules, but I think overall this will become a really cool package!